### PR TITLE
Fix CommandResetInfoRegistry's compareTo so /help works

### DIFF
--- a/src/main/java/sonar/logistics/base/utils/commands/CommandResetInfoRegistry.java
+++ b/src/main/java/sonar/logistics/base/utils/commands/CommandResetInfoRegistry.java
@@ -25,7 +25,7 @@ public class CommandResetInfoRegistry implements ICommand {
 
 	@Override
 	public int compareTo(@Nonnull ICommand o) {
-		return 0;
+		return this.getName().compareTo(o.getName());
 	}
 
 	@Nonnull


### PR DESCRIPTION
When a command's `compareTo` is invalid, `/help` says "An unknown error occurred while attempting to perform this command" because the sort function throws an exception. I used the [HelpFixer](https://minecraft.curseforge.com/projects/helpfixer) mod to determine that Practical Logistics 2 is the offender for me. This also needs to be fixed in the 1.10.2 branch.